### PR TITLE
Add references to readme in proj file

### DIFF
--- a/src/Feliz.ReactSpeedometer/Feliz.ReactSpeedometer.fsproj
+++ b/src/Feliz.ReactSpeedometer/Feliz.ReactSpeedometer.fsproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="*.fsproj; **\*.fs; *.js" PackagePath="fable\" />
-    <None Include="README.md" Pack="true" PackagePath=""/>
+    <None Include="..\..\README.md" Pack="true" PackagePath=""/>
   </ItemGroup>
   <PropertyGroup>
     <NpmDependencies>

--- a/src/Feliz.ReactSpeedometer/Feliz.ReactSpeedometer.fsproj
+++ b/src/Feliz.ReactSpeedometer/Feliz.ReactSpeedometer.fsproj
@@ -8,6 +8,7 @@
     <Company>Compositional IT</Company>
     <PackageProjectUrl>https://github.com/CompositionalIT/Feliz-ReactSpeedometer</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CompositionalIT/Feliz-ReactSpeedometer</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\CIT-logo.png">
@@ -19,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="*.fsproj; **\*.fs; *.js" PackagePath="fable\" />
+    <None Include="README.md" Pack="true" PackagePath=""/>
   </ItemGroup>
   <PropertyGroup>
     <NpmDependencies>


### PR DESCRIPTION
When pushing to nuget there is a warning about a missing readme file. This takes the README.MD from the root and uses that in the package